### PR TITLE
Further parameterization

### DIFF
--- a/ecr.tf
+++ b/ecr.tf
@@ -1,13 +1,13 @@
 resource "aws_ecr_repository" "cxflow" {
   name                 = var.name
-  image_tag_mutability = "MUTABLE"
+  image_tag_mutability = var.ecr_image_tag_mutability
 
   image_scanning_configuration {
-    scan_on_push = true
+    scan_on_push = var.ecr_scan_on_push
   }
 
   encryption_configuration {
-    encryption_type = "AES256"
+    encryption_type = var.ecr_encryption_type
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,30 @@ variable "cidr_block" {
   description = "The CIDR block to apply to the full VPC"
 }
 
+variable "enable_dns_support" {
+  type        = boolean
+  default     = true
+  description = "A boolean flag to enable/disable DNS support in the VPC."
+}
+
+variable "enable_dns_hostnames" {
+  type        = boolean
+  default     = true
+  description = "A boolean flag to enable/disable DNS hostnames in the VPC."
+}
+
+variable "enable_nat_gateway" {
+  type        = boolean
+  default     = true
+  description = "Provides a resource to create a VPC NAT Gateway."
+}
+
+variable "single_nat_gateway" {
+  type        = boolean
+  default     = true
+  description = "All private subnets will route their Internet traffic through this single NAT gateway. The NAT gateway will be placed in the first public subnet in your public_subnets block."
+}
+
 variable "private_subnets" {
   type        = list(string)
   default     = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
@@ -64,4 +88,22 @@ variable "tags" {
   type        = map
   default     = {}
   description = "Additional tags to apply to all resources"
+}
+
+variable "ecr_image_tag_mutability" {
+  type        = string
+  default     = "IMMUTABLE"
+  description = "The tag mutability setting for the repository."
+}
+
+variable "ecr_scan_on_push" {
+  type        = boolean
+  default     = true
+  description = "Indicates whether images are scanned after being pushed to the repository (true) or not scanned (false)."
+}
+
+variable "ecr_encryption_type" {
+  type        = string
+  default     = "AES256"
+  description = "The encryption type to use for the repository. Valid values are AES256 or KMS. Defaults to AES256."
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -14,10 +14,10 @@ module "vpc" {
   azs                  = data.aws_availability_zones.available.names
   private_subnets      = var.private_subnets
   public_subnets       = var.public_subnets
-  enable_dns_support   = true
-  enable_dns_hostnames = true
-  enable_nat_gateway   = true
-  single_nat_gateway   = true
+  enable_dns_support   = var.enable_dns_support
+  enable_dns_hostnames = var.enable_dns_hostnames
+  enable_nat_gateway   = var.enable_nat_gateway
+  single_nat_gateway   = var.single_nat_gateway
 
   tags = merge(local.all_tags, {
     "Name" = var.name


### PR DESCRIPTION
Further parameterization

Aqua Wave complains "VPC is using NAT gateways in only 1 subnet" and "ECR repository mutability setting is set to MUTABLE"

My plan is to run something like `aws ecr put-image-tag-mutability --repository-name $CI_AWS_ECS_CLUSTER --image-tag-mutability MUTABLE --region $REGION` before pushing the tags, and then set back to IMMUTABLE with the same command.