### PR TITLE
Update provider.tf - Bumping hashicorp/terraform-provider-aws to v3.26.0

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.9.0"
+      version = "3.26.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
Bumping hashicorp/terraform-provider-aws to v3.26.0

Fixes the below:
```
Initializing provider plugins...
- Finding latest version of hashicorp/template...
- Finding hashicorp/aws versions matching "3.9.0, >= 3.10.0"...
- Installing hashicorp/template v2.2.0...
Error: Failed to query available provider packages
Could not retrieve the list of available versions for provider hashicorp/aws:
no available releases match the given constraints 3.9.0, >= 3.10.0
- Installed hashicorp/template v2.2.0 (signed by HashiCorp)
- ```