### PR TITLE
Removing pinned version for AWS

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "3.9.0"
     }
   }
   required_version = ">= 0.13"


### PR DESCRIPTION
Pinning versions here is no longer the recommended way, it also impacts a new release of a VPC module, which requires a bigger version than what was previously pinned here.
(https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest)