### PR TITLE
Update security-groups.tf - Terraform Interpolation syntax fix

### DIFF
--- a/security-groups.tf
+++ b/security-groups.tf
@@ -13,7 +13,7 @@ resource "aws_security_group" "alb" {
     protocol    = "tcp"
     from_port   = 443
     to_port     = 443
-    cidr_blocks = "${var.gitlab-cidr-range}"
+    cidr_blocks = var.gitlab-cidr-range
   }
 
   egress {


### PR DESCRIPTION
Terraform Interpolation syntax fix:

Warning: Interpolation-only expressions are deprecated
  on .terraform/modules/cxflow/security-groups.tf line 16, in resource "aws_security_group" "alb":
  16:     cidr_blocks = "${var.gitlab-cidr-range}"
Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"