### PR TITLE
Add VARs for cxflow cpu+mem task def

### DIFF
--- a/modules/ecs_service/main.tf
+++ b/modules/ecs_service/main.tf
@@ -77,8 +77,8 @@ resource "aws_ecs_task_definition" "cxflow" {
   execution_role_arn       = var.ecs_role_arn
   task_role_arn            = var.ecs_role_arn
   network_mode             = "awsvpc"
-  memory                   = "2048"
-  cpu                      = "512"
+  memory                   = var.task_definition_cxflow_memory
+  cpu                      = var.task_definition_cxflow_cpu
   requires_compatibilities = ["FARGATE"]
 
   tags = var.tags

--- a/modules/ecs_service/variables.tf
+++ b/modules/ecs_service/variables.tf
@@ -62,3 +62,22 @@ variable "tags" {
   type        = map
   description = "Additional tags to apply to all resources"
 }
+
+# CPU value 	  | Memory value (MiB)
+# 256 (.25 vCPU)| 512 (0.5GB), 1024 (1GB), 2048 (2GB)
+# 512 (.5 vCPU) |	1024 (1GB), 2048 (2GB), 3072 (3GB), 4096 (4GB)
+# 1024 (1 vCPU) | 2048 (2GB), 3072 (3GB), 4096 (4GB), 5120 (5GB), 6144 (6GB), 7168 (7GB), 8192 (8GB)
+# 2048 (2 vCPU) |	Between 4096 (4GB) and 16384 (16GB) in increments of 1024 (1GB)
+# 4096 (4 vCPU) |	Between 8192 (8GB) and 30720 (30GB) in increments of 1024 (1GB)
+
+variable "task_definition_cxflow_cpu" {
+  type        = number
+  description = "Specify a supported value for the task CPU units, 256,512,1024,2048 etc"
+  default     = "512"
+}
+
+variable "task_definition_cxflow_memory" {
+  type        = number
+  description = "Specify a supported value for the task Memory units - 512,1024,2048 etc"
+  default     = "2048"
+}


### PR DESCRIPTION
Allow to manipulate cpu and memory settings for cxflow task def, with defaults set.